### PR TITLE
Add checkout step to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: macos
     steps:
+      - uses: actions/checkout@v2
       - name: Fastlane Action
         uses: maierj/fastlane-action@v1.2.0
         with:


### PR DESCRIPTION
The ios directory was not found (in fact the working directory was empty) because you left out the checkout step before executing the fastlane action.